### PR TITLE
VCST-4359: Use search stores instead of query

### DIFF
--- a/src/VirtoCommerce.SubscriptionModule.Web/Scripts/blades/filter-detail.js
+++ b/src/VirtoCommerce.SubscriptionModule.Web/Scripts/blades/filter-detail.js
@@ -1,6 +1,6 @@
 angular.module('virtoCommerce.subscriptionModule')
 .controller('virtoCommerce.subscriptionModule.filterDetailController', ['$scope', '$localStorage', 'virtoCommerce.storeModule.stores', 'platformWebApp.settings', 'virtoCommerce.customerModule.members', '$translate',
-    function ($scope, $localStorage, storesAPI, settings, members, $translate) {
+    function ($scope, $localStorage, storesApi, settings, members, $translate) {
         var blade = $scope.blade;
 
         blade.metaFields = [
@@ -32,7 +32,7 @@ angular.module('virtoCommerce.subscriptionModule')
         ];
 
         blade.statuses = settings.getValues({ id: 'Subscription.Status' });
-        blade.stores = storesAPI.query();
+        blade.storeDataSource = (criteria) => storesApi.search(criteria);
         
         $scope.saveChanges = function () {
             angular.copy(blade.currentEntity, blade.origEntity);

--- a/src/VirtoCommerce.SubscriptionModule.Web/Scripts/blades/filter-detail.tpl.html
+++ b/src/VirtoCommerce.SubscriptionModule.Web/Scripts/blades/filter-detail.tpl.html
@@ -1,4 +1,4 @@
-﻿<div class="blade-content">
+<div class="blade-content">
     <div class="blade-inner">
         <div class="inner-block clearfix">
             <form class="form" name="formScope">
@@ -30,11 +30,9 @@
 
 <script type="text/ng-template" id="storeSelector.html">
     <div class="form-input">
-        <ui-select ng-model="blade.currentEntity.storeId">
-            <ui-select-match allow-clear placeholder="{{ 'orders.blades.filter-detail.placeholders.all' | translate }}">{{$select.selected.name}}</ui-select-match>
-            <ui-select-choices repeat="store.id as store in blade.stores | filter: { name: $select.search }">
-                <span ng-bind-html="store.name | highlight: $select.search"></span>
-            </ui-select-choices>
-        </ui-select>
+        <ui-scroll-drop-down data="blade.storeDataSource(criteria)"
+                             placeholder="'orders.blades.filter-detail.placeholders.all'"
+                             ng-model="blade.currentEntity.storeId">
+        </ui-scroll-drop-down>
     </div>
 </script>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4359
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Subscription_3.813.0-pr-109-2c26.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the subscription filter’s store selector from a preloaded list to a search-backed, virtualized dropdown.
> 
> - Replace `storesAPI.query()` with `storesApi.search(criteria)` exposed as `blade.storeDataSource`
> - Update `storeSelector.html` to use `ui-scroll-drop-down` bound to `blade.storeDataSource` instead of `ui-select` on `blade.stores`
> - Minor cleanup: rename `storesAPI` -> `storesApi`, remove BOM in template
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c2641fc0993a3e9ae72922ab7e2072ae83e0d23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->