### PR TITLE
VCST-5163: Stable 15 — Subscription (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.SubscriptionModule.Core/VirtoCommerce.SubscriptionModule.Core.csproj
+++ b/src/VirtoCommerce.SubscriptionModule.Core/VirtoCommerce.SubscriptionModule.Core.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.SubscriptionModule.Data.MySql/VirtoCommerce.SubscriptionModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.SubscriptionModule.Data.MySql/VirtoCommerce.SubscriptionModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SubscriptionModule.Data\VirtoCommerce.SubscriptionModule.Data.csproj" />

--- a/src/VirtoCommerce.SubscriptionModule.Data.PostgreSql/VirtoCommerce.SubscriptionModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.SubscriptionModule.Data.PostgreSql/VirtoCommerce.SubscriptionModule.Data.PostgreSql.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SubscriptionModule.Data\VirtoCommerce.SubscriptionModule.Data.csproj" />

--- a/src/VirtoCommerce.SubscriptionModule.Data.SqlServer/VirtoCommerce.SubscriptionModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.SubscriptionModule.Data.SqlServer/VirtoCommerce.SubscriptionModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SubscriptionModule.Data\VirtoCommerce.SubscriptionModule.Data.csproj" />

--- a/src/VirtoCommerce.SubscriptionModule.Data/ExportImport/SubscriptionExportImport.cs
+++ b/src/VirtoCommerce.SubscriptionModule.Data/ExportImport/SubscriptionExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,7 +29,7 @@ namespace VirtoCommerce.SubscriptionModule.Data.ExportImport
         };
 
 
-        public async Task DoExportAsync(Stream backupStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream backupStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -90,7 +91,7 @@ namespace VirtoCommerce.SubscriptionModule.Data.ExportImport
             await jsonTextWriter.FlushAsync();
         }
 
-        public async Task DoImportAsync(Stream backupStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream backupStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.SubscriptionModule.Data/ExportImport/SubscriptionExportImport.cs
+++ b/src/VirtoCommerce.SubscriptionModule.Data/ExportImport/SubscriptionExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.Collections.Generic;
 using System.IO;
@@ -38,10 +39,10 @@ namespace VirtoCommerce.SubscriptionModule.Data.ExportImport
 
             await using var streamWriter = new StreamWriter(backupStream, Encoding.UTF8);
             await using var jsonTextWriter = new JsonTextWriter(streamWriter);
-            await jsonTextWriter.WriteStartObjectAsync();
+            await jsonTextWriter.WriteStartObjectAsync(cancellationToken);
 
-            await jsonTextWriter.WritePropertyNameAsync("PaymentPlans");
-            await jsonTextWriter.WriteStartArrayAsync();
+            await jsonTextWriter.WritePropertyNameAsync("PaymentPlans", cancellationToken);
+            await jsonTextWriter.WriteStartArrayAsync(cancellationToken);
             var processedCount = 0;
 
             var paymentPlanSearchCriteria = AbstractTypeFactory<PaymentPlanSearchCriteria>.TryCreateInstance();
@@ -61,10 +62,10 @@ namespace VirtoCommerce.SubscriptionModule.Data.ExportImport
                 }
             }
 
-            await jsonTextWriter.WriteEndArrayAsync();
+            await jsonTextWriter.WriteEndArrayAsync(cancellationToken);
 
-            await jsonTextWriter.WritePropertyNameAsync("Subscriptions");
-            await jsonTextWriter.WriteStartArrayAsync();
+            await jsonTextWriter.WritePropertyNameAsync("Subscriptions", cancellationToken);
+            await jsonTextWriter.WriteStartArrayAsync(cancellationToken);
             processedCount = 0;
 
             var subscriptionSearchCriteria = AbstractTypeFactory<SubscriptionSearchCriteria>.TryCreateInstance();
@@ -85,10 +86,10 @@ namespace VirtoCommerce.SubscriptionModule.Data.ExportImport
                 }
             }
 
-            await jsonTextWriter.WriteEndArrayAsync();
+            await jsonTextWriter.WriteEndArrayAsync(cancellationToken);
 
-            await jsonTextWriter.WriteEndObjectAsync();
-            await jsonTextWriter.FlushAsync();
+            await jsonTextWriter.WriteEndObjectAsync(cancellationToken);
+            await jsonTextWriter.FlushAsync(cancellationToken);
         }
 
         public async Task DoImportAsync(Stream backupStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
@@ -100,7 +101,7 @@ namespace VirtoCommerce.SubscriptionModule.Data.ExportImport
 
             using var streamReader = new StreamReader(backupStream, Encoding.UTF8);
             await using var jsonReader = new JsonTextReader(streamReader);
-            while (await jsonReader.ReadAsync())
+            while (await jsonReader.ReadAsync(cancellationToken))
             {
                 if (jsonReader.TokenType != JsonToken.PropertyName)
                 {

--- a/src/VirtoCommerce.SubscriptionModule.Data/VirtoCommerce.SubscriptionModule.Data.csproj
+++ b/src/VirtoCommerce.SubscriptionModule.Data/VirtoCommerce.SubscriptionModule.Data.csproj
@@ -18,10 +18,10 @@
   </ItemGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.SubscriptionModule.Web/Module.cs
+++ b/src/VirtoCommerce.SubscriptionModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -137,12 +138,12 @@ namespace VirtoCommerce.SubscriptionModule.Web
             // Method intentionally left empty.
         }
 
-        public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             return _applicationBuilder.ApplicationServices.GetRequiredService<SubscriptionExportImport>().DoExportAsync(outStream, progressCallback, cancellationToken);
         }
 
-        public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             return _applicationBuilder.ApplicationServices.GetRequiredService<SubscriptionExportImport>().DoImportAsync(inputStream, progressCallback, cancellationToken);
         }

--- a/src/VirtoCommerce.SubscriptionModule.Web/VirtoCommerce.SubscriptionModule.Web.csproj
+++ b/src/VirtoCommerce.SubscriptionModule.Web/VirtoCommerce.SubscriptionModule.Web.csproj
@@ -21,7 +21,7 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem" Version="3.1009.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SubscriptionModule.Core\VirtoCommerce.SubscriptionModule.Core.csproj" />

--- a/src/VirtoCommerce.SubscriptionModule.Web/module.manifest
+++ b/src/VirtoCommerce.SubscriptionModule.Web/module.manifest
@@ -3,13 +3,13 @@
   <id>VirtoCommerce.Subscription</id>
   <version>3.1002.0</version>
   <version-tag />
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
+    <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1009.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>Subscriptions</title>

--- a/tests/VirtoCommerce.SubscriptionModule.Test/SubscriptionExportImportTests.cs
+++ b/tests/VirtoCommerce.SubscriptionModule.Test/SubscriptionExportImportTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -121,7 +122,7 @@ namespace VirtoCommerce.SubscriptionModule.Tests
         private readonly Mock<ISubscriptionSearchService> _subscriptionSearchService;
         private readonly Mock<IPaymentPlanService> _paymentPlanService;
         private readonly Mock<IPaymentPlanSearchService> _paymentPlanSearchService;
-        private readonly Mock<ICancellationToken> _cancellationToken;
+        private readonly CancellationToken _cancellationToken;
         private readonly SubscriptionExportImport _subscriptionExportImport;
 
         public SubscriptionExportImportTests()
@@ -134,7 +135,7 @@ namespace VirtoCommerce.SubscriptionModule.Tests
             _subscriptionExportImport = new SubscriptionExportImport(_subscriptionService.Object, _subscriptionSearchService.Object,
                 _paymentPlanSearchService.Object, _paymentPlanService.Object, GetJsonSerializer());
 
-            _cancellationToken = new Mock<ICancellationToken>();
+            _cancellationToken = CancellationToken.None;
         }
 
         private static void IgnoreProgressInfo(ExportImportProgressInfo progressInfo)
@@ -192,7 +193,7 @@ namespace VirtoCommerce.SubscriptionModule.Tests
 
             using (var targetStream = new MemoryStream())
             {
-                await _subscriptionExportImport.DoExportAsync(targetStream, IgnoreProgressInfo, _cancellationToken.Object);
+                await _subscriptionExportImport.DoExportAsync(targetStream, IgnoreProgressInfo, _cancellationToken);
 
                 // DoExportAsync() closes targetStream, so extracting data from it is a bit tricky...
                 var streamContents = targetStream.ToArray();
@@ -204,7 +205,7 @@ namespace VirtoCommerce.SubscriptionModule.Tests
             }
 
             var importStream = GetStreamFromString(actualJson);
-            await _subscriptionExportImport.DoImportAsync(importStream, IgnoreProgressInfo, _cancellationToken.Object);
+            await _subscriptionExportImport.DoImportAsync(importStream, IgnoreProgressInfo, _cancellationToken);
 
             //Assert
             TestSubscriptions.Should().BeEquivalentTo(actualSubscriptions);


### PR DESCRIPTION
Part of **Stable 15** (Wave 7). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Waves 1–6 packages on nuget.org. Version handled by CI.

- ICT migration; Customer dep bumped to 3.1011.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency and platform API alignment can surface breaking changes at runtime; export/import behavior changes only around cooperative cancellation wiring, with tests updated.
> 
> **Overview**
> Updates the Subscription module for **Stable 15** by targeting **platform 3.1039.0** and matching Virto Commerce package versions across Core, Data, DB providers, Web, and `module.manifest` (including **Customer 3.1011.0**).
> 
> Completes the platform **ICT migration** for backup/restore: `Module` export/import entry points and `SubscriptionExportImport` now use `CancellationToken` instead of `ICancellationToken`, and Newtonsoft `JsonTextWriter` / `JsonTextReader` async calls pass that token through. Unit tests use `CancellationToken.None` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfb4d7110df1549b9d4f6c4e019e1640e082447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Subscription_3.1002.0-pr-115-3bfb.zip