### PR TITLE
Fix: log a warning instead of failing when a subscription has no CustomerOrderPrototype

### DIFF
--- a/src/VirtoCommerce.SubscriptionModule.Data/Services/SubscriptionBuilder.cs
+++ b/src/VirtoCommerce.SubscriptionModule.Data/Services/SubscriptionBuilder.cs
@@ -143,15 +143,15 @@ namespace VirtoCommerce.SubscriptionModule.Data.Services
             CustomerOrder retVal = null;
             if (!Subscription.IsCancelled)
             {
-                if (Subscription.CustomerOrderPrototype == null)
-                {
-                    logger.LogWarning("Subscription {subscriptionId} - {subscriptionNumber} has no CustomerOrderPrototype", Subscription.Id, Subscription.Number);
-                    return null;
-                }
-
                 var now = DateTime.UtcNow;
                 if (forceCreation || now >= Subscription.CurrentPeriodEnd)
                 {
+                    if (Subscription.CustomerOrderPrototype == null)
+                    {
+                        logger.LogWarning("Subscription {subscriptionId} - {subscriptionNumber} has no CustomerOrderPrototype", Subscription.Id, Subscription.Number);
+                        return null;
+                    }
+
                     Subscription.CurrentPeriodStart = now;
                     Subscription.CurrentPeriodEnd = GetPeriodEnd(now, Subscription.Interval, Subscription.IntervalCount);
 

--- a/src/VirtoCommerce.SubscriptionModule.Data/Services/SubscriptionBuilder.cs
+++ b/src/VirtoCommerce.SubscriptionModule.Data/Services/SubscriptionBuilder.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.OrdersModule.Core.Model;
@@ -21,7 +21,8 @@ namespace VirtoCommerce.SubscriptionModule.Data.Services
         IPaymentPlanService paymentPlanService,
         ISettingsManager settingsManager,
         IStoreService storeService,
-        IUniqueNumberGenerator uniqueNumberGenerator)
+        IUniqueNumberGenerator uniqueNumberGenerator,
+        ILogger<SubscriptionBuilder> logger)
         : ISubscriptionBuilder
     {
         private Subscription _subscription;
@@ -142,6 +143,12 @@ namespace VirtoCommerce.SubscriptionModule.Data.Services
             CustomerOrder retVal = null;
             if (!Subscription.IsCancelled)
             {
+                if (Subscription.CustomerOrderPrototype == null)
+                {
+                    logger.LogWarning("Subscription {subscriptionId} - {subscriptionNumber} has no CustomerOrderPrototype", Subscription.Id, Subscription.Number);
+                    return null;
+                }
+
                 var now = DateTime.UtcNow;
                 if (forceCreation || now >= Subscription.CurrentPeriodEnd)
                 {
@@ -149,21 +156,25 @@ namespace VirtoCommerce.SubscriptionModule.Data.Services
                     Subscription.CurrentPeriodEnd = GetPeriodEnd(now, Subscription.Interval, Subscription.IntervalCount);
 
                     retVal = CloneCustomerOrder(Subscription.CustomerOrderPrototype);
+
                     retVal.Status = "New";
                     retVal.IsPrototype = false;
                     retVal.SubscriptionId = Subscription.Id;
                     retVal.SubscriptionNumber = Subscription.Number;
+
                     foreach (var payment in retVal.InPayments)
                     {
                         payment.PaymentStatus = PaymentStatus.New;
                     }
+
                     foreach (var shipment in retVal.Shipments)
                     {
                         shipment.Status = "New";
                     }
 
-                    _subscription.CustomerOrders ??= new List<CustomerOrder>();
+                    _subscription.CustomerOrders ??= [];
                     _subscription.CustomerOrders.Add(retVal);
+
                     await ActualizeAsync();
                 }
             }
@@ -186,6 +197,8 @@ namespace VirtoCommerce.SubscriptionModule.Data.Services
 
         protected virtual CustomerOrder CloneCustomerOrder(CustomerOrder order)
         {
+            ArgumentNullException.ThrowIfNull(order);
+
             // without ObjectCreationHandling.Replace default constructor values will be added to result
             var serializationSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All, ObjectCreationHandling = ObjectCreationHandling.Replace };
 

--- a/src/VirtoCommerce.SubscriptionModule.Data/Services/SubscriptionService.cs
+++ b/src/VirtoCommerce.SubscriptionModule.Data/Services/SubscriptionService.cs
@@ -78,7 +78,7 @@ public class SubscriptionService(
 
         if (order == null)
         {
-            throw new SubscriptionException($"Cannot create order for subscription with id {subscription.Id}. Subscription is not active or has no payment plan.");
+            throw new SubscriptionException($"Cannot create order for subscription with id {subscription.Id}. Check logs for details.");
         }
 
         await customerOrderService.SaveChangesAsync([order]);


### PR DESCRIPTION
## Description
Previously a subscription without a CustomerOrderPrototype interrupted processing. Such subscriptions are now skipped with a warning, so the rest of the batch continues to be processed.


## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Subscription_3.1003.0-pr-119-c566.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in subscription order creation with logging; explicit API path still fails with an exception when order creation returns null.
> 
> **Overview**
> **Recurrent order creation** no longer blows up when a subscription has no `CustomerOrderPrototype`. `TryToCreateRecurrentOrderAsync` logs a warning with subscription id/number and returns `null` instead of calling `CloneCustomerOrder` on a null prototype, so batch jobs (e.g. `CreateRecurrentOrdersJob`) can keep processing other subscriptions.
> 
> `SubscriptionBuilder` now takes `ILogger<SubscriptionBuilder>`. `CloneCustomerOrder` uses `ArgumentNullException.ThrowIfNull` for clearer failures if null is passed elsewhere. `CreateOrderForSubscription` still throws when no order is created, but the message now says to **check logs** rather than blaming inactive state or missing payment plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c566758c3362fe040ce3b4f0959dfc5044efb3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->